### PR TITLE
hotfix: removing deprecated method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,4 @@
-# Product Assembly
-
-[![Build Status](https://travis-ci.org/spree-contrib/spree-product-assembly.svg?branch=master)](https://travis-ci.org/spree-contrib/spree-product-assembly)
-[![Code Climate](https://codeclimate.com/github/spree-contrib/spree-product-assembly/badges/gpa.svg)](https://codeclimate.com/github/spree-contrib/spree-product-assembly)
+# Product Assembly - Neolife Fork
 
 Create a product which is composed of other products.
 
@@ -12,7 +9,7 @@ Create a product which is composed of other products.
 1. Add this extension to your Gemfile with this line:
 
     ```ruby
-    gem 'spree_product_assembly', github: 'spree-contrib/spree-product-assembly'
+    gem 'spree_product_assembly', github: 'grupo-neolife/spree-product-assembly'
     ```
 
 

--- a/app/views/spree/admin/orders/_assemblies.html.erb
+++ b/app/views/spree/admin/orders/_assemblies.html.erb
@@ -22,7 +22,6 @@
               <td class="item-image"><%= mini_image(item.variant) %></td>
               <td class="item-name">
                 <%= item.product.name %> - <%= item.variant.sku %> <br />
-                <%= "(" + variant_options(item.variant) + ")" if item.variant.option_values.any? %>
               </td>
               <td class="item-price align-center">
                 <%= item.single_money.to_html %>


### PR DESCRIPTION
the variant_options method does not exist in the version of the spree we are using